### PR TITLE
Buildparams

### DIFF
--- a/internal/pkg/imageurl/urls.go
+++ b/internal/pkg/imageurl/urls.go
@@ -18,15 +18,26 @@ package imageurl
 
 import (
 	"fmt"
+	log "k8s.io/klog"
 	"net/url"
+	"os"
 	"strings"
 )
-
 type ImageURL struct {
 	URL       *url.URL
 	Namespace string
 	Image     string
 	Tag       string
+}
+
+func NewImageUrl(buildImage string) ImageURL {
+	var imgurl ImageURL
+	err := imgurl.Parse(buildImage)
+	if err != nil {
+		log.Errorf("Malformed BuildImage url provided in metaGraf file; %v", buildImage)
+		os.Exit(1)
+	}
+	return imgurl
 }
 
 func (u *ImageURL) Parse(url string) error {

--- a/internal/pkg/params/params.go
+++ b/internal/pkg/params/params.go
@@ -39,6 +39,8 @@ var (
 
 	// PropertiesFile, assigned with --cvfile.
 	PropertiesFile string
+	// BuildParams Slice of strings to hold overridden values when using dev-build command.
+	BuildParams    []string
 
 	// Potentially used by BuildConfig creation to override output imagestream
 	OutputImagestream string

--- a/mg/cmd/create-buildconfig.go
+++ b/mg/cmd/create-buildconfig.go
@@ -34,6 +34,7 @@ func init() {
 	createBuildConfigCmd.Flags().StringVarP(&Namespace, "namespace", "n", "", "namespace to work on, if not supplied it will use current working namespace")
 	createBuildConfigCmd.Flags().StringVar(&params.SourceRef, "ref", "", "specify source ref or branch name.")
 	createBuildConfigCmd.Flags().StringSliceVar(&CVars, "cvars", []string{}, "Slice of key=value pairs, seperated by ,")
+	createBuildConfigCmd.Flags().StringSliceVar(&params.BuildParams, "buildparams", []string{}, "Slice of key=value pairs, seperated by ,")
 }
 
 var createBuildConfigCmd = &cobra.Command{

--- a/mg/cmd/dev.go
+++ b/mg/cmd/dev.go
@@ -75,6 +75,7 @@ func init() {
 	devCmdBuild.Flags().StringVar(&params.SourceRef, "ref", "", "Specify the git ref or branch ref to build.")
 	devCmdBuild.Flags().StringVarP(&params.NameSpace, "namespace", "n", "", "namespace to work on, if not supplied it will use current active namespace.")
 	devCmdBuild.Flags().BoolVar(&params.LocalBuild, "local", false, "Builds application from src in current (.) direcotry.")
+	devCmdBuild.Flags().StringSliceVar(&params.BuildParams, "buildparams", []string{}, "Slice of key=value pairs, seperated by , to override or append build params used by underlying build mechanism")
 
 	devCmd.AddCommand(devCmdWatch)
 	devCmdWatch.Flags().StringVarP(&params.NameSpace, "namespace", "n", "", "namespace to work on, if not supplied it will use current active namespace.")

--- a/mg/cmd/properties.go
+++ b/mg/cmd/properties.go
@@ -43,7 +43,7 @@ func PropertiesFromEnv(mgp metagraf.MGProperties) metagraf.MGProperties {
 // Modifies a MGProperties map with values from --cvars
 // argument. Only supports local environment variables
 // for now.
-func PropertiesFromCmd(mgp metagraf.MGProperties) metagraf.MGProperties {
+func propertiesFromCmdUsingCvarsFlag(mgp metagraf.MGProperties) metagraf.MGProperties {
 	// Parse and get values from --cvars
 	cvars := CmdCVars(CVars).Parse()
 	for k, v := range cvars {
@@ -69,8 +69,8 @@ func MgPropertyLineSplit(r rune) bool {
 	return r == '|' || r == '='
 }
 
-// ReadPropertiesFromFile Reads a properties file and returns a metagraf.MGProperties structure
-func ReadPropertiesFromFile(propfile string) metagraf.MGProperties {
+// propertiesFromFile Reads a properties file and returns a metagraf.MGProperties structure
+func propertiesFromFile(propfile string) metagraf.MGProperties {
 	if len(propfile) > 0 {
 		file, err := os.Open(propfile)
 		if err != nil {
@@ -83,15 +83,14 @@ func ReadPropertiesFromFile(propfile string) metagraf.MGProperties {
 				log.Warningf("Unable to close file: %v", err)
 			}
 		}()
-		return ParseProps(file)
+		return parseProps(file)
 	} else {
 		return metagraf.MGProperties{}
 	}
 
 }
 
-
-func ParseProps(reader io.Reader) metagraf.MGProperties {
+func parseProps(reader io.Reader) metagraf.MGProperties {
 	mgProps := metagraf.MGProperties{}
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanLines)

--- a/mg/cmd/properties_test.go
+++ b/mg/cmd/properties_test.go
@@ -7,8 +7,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
+
+
+func TestGettingToKnowGo(t *testing.T) {
+	myMap := make(map[string]string)
+	myMap["nisse"] = "Nasse"
+	myMap["Ludde"] = "Ladde"
+
+	if myMap["nisse"] != "" {
+		fmt.Println("It exists!")
+	}
+
+	if val, ok := myMap["Ludde"]; ok {
+		fmt.Printf("I exists! The lookup returned %v and the value is %s ", ok, val)
+	}
+
+	if strings.HasPrefix(myMap["bla"], "nis") {
+		fmt.Println("Should not print this")
+	}
+
+	if strings.HasPrefix(myMap["nisse"], "Na") {
+		assert.True(t, true, "Value starts with Na??")
+	}else{
+		fmt.Println("Hey, missed conditional statement above!")
+	}
+
+}
 
 func TestSimpleLocalSourceProperty(t *testing.T) {
 	propertyFileContent := fileContent("local|Nisse=Nasse")

--- a/mg/cmd/properties_test.go
+++ b/mg/cmd/properties_test.go
@@ -7,35 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 )
-
-
-func TestGettingToKnowGo(t *testing.T) {
-	myMap := make(map[string]string)
-	myMap["nisse"] = "Nasse"
-	myMap["Ludde"] = "Ladde"
-
-	if myMap["nisse"] != "" {
-		fmt.Println("It exists!")
-	}
-
-	if val, ok := myMap["Ludde"]; ok {
-		fmt.Printf("I exists! The lookup returned %v and the value is %s ", ok, val)
-	}
-
-	if strings.HasPrefix(myMap["bla"], "nis") {
-		fmt.Println("Should not print this")
-	}
-
-	if strings.HasPrefix(myMap["nisse"], "Na") {
-		assert.True(t, true, "Value starts with Na??")
-	}else{
-		fmt.Println("Hey, missed conditional statement above!")
-	}
-
-}
 
 func TestSimpleLocalSourceProperty(t *testing.T) {
 	propertyFileContent := fileContent("local|Nisse=Nasse")

--- a/mg/cmd/properties_test.go
+++ b/mg/cmd/properties_test.go
@@ -13,7 +13,7 @@ import (
 func TestSimpleLocalSourceProperty(t *testing.T) {
 	propertyFileContent := fileContent("local|Nisse=Nasse")
 
-	actualResult := ParseProps(&propertyFileContent)
+	actualResult := parseProps(&propertyFileContent)
 	actualProperty := actualResult["local|Nisse"]
 
 	expectedProperty := metagraf.MGProperty{
@@ -30,7 +30,7 @@ func TestPropertyWithMultipleEqualsSigns(t *testing.T) {
 	propertyFileContent := fileContent(
 		"local|JAVA_OPTIONS=-Dconfig.file=/config/application.properties")
 
-	actualResult := ParseProps(&propertyFileContent)
+	actualResult := parseProps(&propertyFileContent)
 	actualProperty := actualResult["local|JAVA_OPTIONS"]
 
 	expectedProperty := metagraf.MGProperty{
@@ -51,7 +51,7 @@ func TestMissingSourceHintFunctionShouldExit(t *testing.T) {
 	// Solution is proposed by golang authors, though :-D
 	// A better solution is to refactor the function under test to return error as opposed to do a hard exit of the program
 	if os.Getenv("BE_CRASHER") == "1" {
-		ParseProps(&propertyFileContent)
+		parseProps(&propertyFileContent)
 		return
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=TestMissingSourceHintFunctionShouldExit")
@@ -69,7 +69,7 @@ func TestMultipleProperties(t *testing.T) {
 		"local|JAVA_OPTIONS=-Dconfig.file=/config/application.properties\n" +
 				"build|MAVEN_OPS=-xms123m,-aaa4311G\n")
 
-	actualResult := ParseProps(&propertyFileContent)
+	actualResult := parseProps(&propertyFileContent)
 	actualProperty1 := actualResult["local|JAVA_OPTIONS"]
 	actualProperty2 := actualResult["build|MAVEN_OPS"]
 
@@ -103,7 +103,7 @@ func TestPropertiesFile(t *testing.T) {
 	_, err = tempFile.WriteString(fileContent)
 	check(err)
 
-	actualResult := ReadPropertiesFromFile(tempFile.Name())
+	actualResult := propertiesFromFile(tempFile.Name())
 
 	actualProperty1 := actualResult["local|JAVA_OPTIONS"]
 	actualProperty2 := actualResult["build|MAVEN_OPS"]

--- a/pkg/modules/buildsource.go
+++ b/pkg/modules/buildsource.go
@@ -1,0 +1,59 @@
+package modules
+
+import (
+	"github.com/laetho/metagraf/internal/pkg/params"
+	"github.com/laetho/metagraf/pkg/metagraf"
+	buildv1 "github.com/openshift/api/build/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Generate build sources
+
+func ConstructBuildSource(mg *metagraf.MetaGraf) buildv1.BuildSource {
+	var buildsource buildv1.BuildSource
+	if len(mg.Spec.BaseRunImage) > 0 && len(mg.Spec.Repository) > 0 {
+		buildsource = genBinaryBuildSource()
+	} else if len(mg.Spec.BuildImage) > 0 && len(mg.Spec.BaseRunImage) < 1 {
+		buildsource = genGitBuildSource(mg)
+	}
+	return buildsource
+}
+
+func genBinaryBuildSource() buildv1.BuildSource {
+	return buildv1.BuildSource{
+		Type:   "Source",
+		Binary: &buildv1.BinaryBuildSource{},
+	}
+}
+
+func genGitBuildSource(mg *metagraf.MetaGraf) buildv1.BuildSource {
+
+	// When using the Git repository as a source without specifying the ref field,
+	//OpenShift Enterprise performs a shallow clone (--depth=1 clone).
+	//That means only the HEAD (usually the master branch) is downloaded.
+	//This results in repositories downloading faster, including the commit history.
+	// https://docs.openshift.com/enterprise/3.2/dev_guide/builds.html#source-code
+
+	var branch string
+	if len(params.SourceRef) > 0 {
+		branch = params.SourceRef
+	} else {
+		branch = mg.Spec.Branch
+	}
+
+	bs := buildv1.BuildSource{
+		Type: "Git",
+		Git: &buildv1.GitBuildSource{
+			URI: mg.Spec.Repository,
+			Ref: branch,
+		},
+	}
+
+	if len(mg.Spec.RepSecRef) > 0 {
+		bs.SourceSecret = &corev1.LocalObjectReference{
+			Name: mg.Spec.RepSecRef,
+		}
+	}
+
+	return bs
+}


### PR DESCRIPTION
Innført --buildparams for `create buildconfig`. Flagget er ment å skulle erstatte eller tilføre byggeparametre som man ellers angir under environment.build i metagraf.json. Flagget overlapper med --cvars, men der --cvars blir litt implisitt og utydelig på om det er environment.local eller andre variabler, er --buildparams eksplisitt, og vil kun gjelde environment.build-seksjonen i metagraf. Flagget er kun relevant for buildconfig og `mg dev build` 