### PR TITLE
WIP: Add initial taskfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mg/test.sh
 
 dist/
 dist/
+.task/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,45 @@
+# https://taskfile.dev
+version: '3'
+
+
+tasks:
+  build:
+    desc: build binary
+    env:
+      CGO_ENABLED: 0
+    vars:
+      GITHASH:
+        sh: git rev-parse --short HEAD
+      GITTAG:
+        sh: git tag -l --points-at HEAD
+      GITBRANCH:
+        sh: git rev-parse --abbrev-ref HEAD
+    dir: mg
+    sources:
+    - "**/*.go"
+    generates:
+      - mg
+    cmds: 
+    - |
+      go build -ldflags "-extldflags '-static'
+      -X 'github.com/laetho/metagraf/pkg/mgver.GitHash={{.GITHASH}}' 
+      -X 'github.com/laetho/metagraf/pkg/mgver.GitTag={{.GITTAG}}' 
+      -X 'github.com/laetho/metagraf/pkg/mgver.GitBranch={{.GITBRANCH}}'"
+
+
+  setup:
+    desc: install dependencies
+    cmds:
+      - go mod tidy
+  
+  test:
+    desc: run tests
+    cmds:
+      - go vet ./...
+      - go test ./...
+  
+  default:
+    cmds:
+      - task: setup
+      - task: test
+      - task: build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,8 +36,13 @@ tasks:
     desc: run tests
     cmds:
       - go vet ./...
-      - go test ./...
+      - go test ./... -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt
   
+  cover:
+    desc: open the cover tool
+    cmds:
+      - go tool cover -html=coverage.txt
+
   default:
     cmds:
       - task: setup


### PR DESCRIPTION
`task` kan installeres med `brew install go-task/tap/go-task` på mac