### PR TITLE
Add feature to ignore missing environment variables. Useful when all …

### DIFF
--- a/internal/pkg/params/params.go
+++ b/internal/pkg/params/params.go
@@ -103,4 +103,5 @@ var (
 	CreateStatefulSetPersistentVolumeClaim       bool = false
 	StatefulSetPersistentVolumeClaimStorageClass string
 	StatefulSetPersistentVolumeClaimSize         string
+	IgnoreMissingEnv = false // Command line flag to ignore missing environment variables in metagraf.json
 )

--- a/mg/cmd/create-deployment.go
+++ b/mg/cmd/create-deployment.go
@@ -31,6 +31,7 @@ func init() {
 	createDeploymentCmd.Flags().StringVar(&params.PodAntiAffinityTopologyKey, "anti-affinity-topology-key", "", "Define which node label to use as a topologyKey (describing a datacenter, zone or a rack as an example)")
 	createDeploymentCmd.Flags().Int32Var(&params.PodAntiAffinityWeight, "pod-anti-affinity-weight", params.PodAntiAffinityWeightDefault, "Weight for WeightedPodAffinityTerm.")
 	createDeploymentCmd.Flags().BoolVar(&params.DownwardAPIEnvVars,"downward-api-envvars",false,"Enables generation of environment variables from Downward API. An opinionated selection.")
+	createDeploymentCmd.Flags().BoolVar(&IgnoreMissingEnv, "ignore-missing-env", false, "Ignore missing environment variables")
 }
 
 var createDeploymentCmd = &cobra.Command{

--- a/mg/cmd/properties.go
+++ b/mg/cmd/properties.go
@@ -238,4 +238,5 @@ func FlagPassingHack() {
 	modules.OName = OName
 	modules.Context = Context
 	modules.CreateGlobals = CreateGlobals
+	modules.IgnoreMissingEnv = IgnoreMissingEnv
 }

--- a/mg/cmd/root.go
+++ b/mg/cmd/root.go
@@ -61,6 +61,7 @@ var (
 
 	// Holds a slice of paths to ignore in mg dev watch cmd.
 	IgnoredPaths []string
+	IgnoreMissingEnv bool = false // Command line flag to ignore missing environment variables in metagraf.json
 )
 
 // Array of available config keys

--- a/pkg/modules/common.go
+++ b/pkg/modules/common.go
@@ -56,6 +56,7 @@ var (
 	CreateGlobals bool
 	// Sets the default pull policy for all metagraf modules
 	PullPolicy corev1.PullPolicy = corev1.PullIfNotPresent
+	IgnoreMissingEnv bool = false
 )
 
 var Variables metagraf.MGProperties

--- a/pkg/modules/deployment.go
+++ b/pkg/modules/deployment.go
@@ -100,7 +100,7 @@ func GenDeployment(mg *metagraf.MetaGraf, namespace string) {
 	}
 
 	EnvVars, err = GetEnvVars(mg, Variables)
-	if err != nil {
+	if err != nil && IgnoreMissingEnv == false {
 		glog.Error(err)
 		panic(err)
 	}


### PR DESCRIPTION
…you want is parts of the created deployment manifest